### PR TITLE
x3270 no longer supports the ignore script command

### DIFF
--- a/py3270/__init__.py
+++ b/py3270/__init__.py
@@ -333,7 +333,7 @@ class Emulator(object):
         try:
             # this is basically a no-op, but it results in the the current status
             # getting updated
-            self.exec_command(b'ignore')
+            self.exec_command(b'Query(ConnectionState)')
 
             # connected status is like 'C(192.168.1.1)', disconnected is 'N'
             return self.status.connection_state.startswith(b'C(')


### PR DESCRIPTION
Update py3270 to use 'Query(ConnectionState)' instead of the 'ignore' command
when checking whether the emulator is still connected. x3270 no longer uses the
ignore command (ref http://x3270.bgp.nu/x3270-script.html)