### PR TITLE
Improvements socket wc3270

### DIFF
--- a/py3270/__init__.py
+++ b/py3270/__init__.py
@@ -10,6 +10,7 @@ import socket
 import subprocess
 import time
 import warnings
+import errno
 
 log = logging.getLogger(__name__)
 
@@ -219,7 +220,8 @@ class Wc3270App(ExecutableApp):
                 sock.connect(("127.0.0.1", self.script_port))
                 break
             except socket.error as e:
-                if "actively refused it" not in str(e):
+                log.warn(e)
+                if e.errno != errno.ECONNREFUSED:
                     raise
                 time.sleep(1)
                 count += 1
@@ -319,7 +321,7 @@ class Emulator(object):
                 # x3270 was terminated, since we are just quitting anyway, ignore it.
                 pass
             except socket.error as e:
-                if "was forcibly closed" not in str(e):
+                if e.errno != errno.ECONNRESET:
                     raise
                 # this can happen because wc3270 closes the socket before
                 # the read() can happen, causing a socket error

--- a/py3270/__init__.py
+++ b/py3270/__init__.py
@@ -150,7 +150,11 @@ class ExecutableApp(object):
         return False
 
     def close(self):
-        self.sp.kill()
+        if self.sp.poll() is None:
+            self.sp.terminate()        
+        return_code = self.sp.returncode or self.sp.poll()
+        log.debug("return code: %d", return_code)
+        return return_code
 
     def write(self, data):
         self.sp.stdin.write(data)

--- a/py3270/__init__.py
+++ b/py3270/__init__.py
@@ -481,7 +481,7 @@ class Emulator(object):
             raises: FieldTruncateError if `tosend` is longer than
                 `length`.
         """
-        if length - len(tosend) < 0:
+        if length < len(tosend):
             raise FieldTruncateError('length limit %d, but got "%s"' % (length, tosend))
         if xpos is not None and ypos is not None:
             self.move_to(ypos, xpos)

--- a/py3270/__init__.py
+++ b/py3270/__init__.py
@@ -151,7 +151,7 @@ class ExecutableApp(object):
 
     def close(self):
         if self.sp.poll() is None:
-            self.sp.terminate()        
+            self.sp.terminate()
         return_code = self.sp.returncode or self.sp.poll()
         log.debug("return code: %d", return_code)
         return return_code
@@ -221,7 +221,7 @@ class Wc3270App(ExecutableApp):
         count = 0
         while count < 15:
             try:
-                sock.connect(('localhost', self.script_port))
+                sock.connect(("localhost", self.script_port))
                 break
             except socket.error as e:
                 log.warn(e)

--- a/py3270/__init__.py
+++ b/py3270/__init__.py
@@ -217,7 +217,7 @@ class Wc3270App(ExecutableApp):
         count = 0
         while count < 15:
             try:
-                sock.connect(("127.0.0.1", self.script_port))
+                sock.connect(('localhost', self.script_port))
                 break
             except socket.error as e:
                 log.warn(e)


### PR DESCRIPTION
Error handling socket via errno module instead of messages (i18n problems).
Signal correction for termination of the subprocess.
