### PR TITLE
Allow port to be specified for wc3270

### DIFF
--- a/py3270/__init__.py
+++ b/py3270/__init__.py
@@ -188,11 +188,11 @@ class Wc3270App(ExecutableApp):
     executable = "wc3270"
     # see notes for args in x3270App
     args = ["-xrm", "wc3270.unlockDelay: False"]
-    script_port = 17938
 
-    def __init__(self, args):
+    def __init__(self, args=None, script_port=17938):
         if args:
             self.args = Wc3270App.args + args
+        self.script_port = script_port
         self.sp = None
         self.socket_fh = None
 


### PR DESCRIPTION
Hello!

This is a minor change to users of wc3270 to specify the port being used. If not specified, it defaults to 17938 as before.

This is needed to allow multiple instances of wc3270 to run.

Let me know what else I need to do to get this code pulled in! Its been reported as an issue #35