### PR TITLE
Fix TypeError when closing and already closed app

### DIFF
--- a/py3270/__init__.py
+++ b/py3270/__init__.py
@@ -153,7 +153,7 @@ class ExecutableApp(object):
         if self.sp.poll() is None:
             self.sp.terminate()
         return_code = self.sp.returncode or self.sp.poll()
-        log.debug("return code: %d", return_code)
+        log.debug("return code: %s", return_code)
         return return_code
 
     def write(self, data):


### PR DESCRIPTION
When app is already closed, the variable `return_code` is _None_ and _log.debug()_ function throws a `TypeError` because it expects an integer. Here is the stack trace of the error:

```
TypeError: %d format: a real number is required, not NoneType
Call stack:
  File ".\venv\Lib\site-packages\py3270\__init__.py", line 333, in terminate
    self.app.close()
  File ".\venv\Lib\site-packages\py3270\__init__.py", line 156, in close
    log.debug("return code: %d", return_code)
Message: 'return code: %d'
Arguments: (None,)
```