### PR TITLE
Fix test issues with missing decoding

### DIFF
--- a/tests/test_emulator.py
+++ b/tests/test_emulator.py
@@ -135,7 +135,7 @@ class TestEmulator(object):
         m_string_get.return_value = "foobar"
 
         assert em.string_found(7, 9, "foobar")
-        m_string_get.assert_called_once_with(7, 9, 6)
+        m_string_get.assert_called_once_with(7, 9, 6, decode="utf-8")
 
         assert not em.string_found(7, 9, "baz")
 


### PR DESCRIPTION
A pytest test is broken because a it checks the arguments that a mock method has been called with. 
An extra (keyword) argument is used for decoding, which was not accounted for previously 
(probably broken in 0f325768e12f3fc82249e131a507e4d4ce5ec0dd).

