### PR TITLE
Fix tests issue with pytest.raises

### DIFF
--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
-
+import re
 from unittest import mock
 
 from pytest import raises
@@ -13,7 +13,7 @@ class TestCommand(object):
     def test_defaults(self):
         cmd = MCommand()
         assert cmd.cmdstr == b"testcmd"
-        assert cmd.status_line == None
+        assert cmd.status_line is None
         assert cmd.data == []
 
     @mock.patch.object(ExamApp, "write")
@@ -40,25 +40,25 @@ class TestCommand(object):
         data = "data: some kind \n"
         data += "data: of error\n"
         cmd = MCommand(data, result="error")
-        with raises(CommandError, message="some kind of error"):
+        with raises(CommandError, match="some kind of error"):
             cmd.execute()
 
     def test_error_response_no_data(self):
         cmd = MCommand(result="error")
-        with raises(CommandError, message="[no error message]"):
+        with raises(CommandError, match="[no error message]"):
             cmd.execute()
 
     def test_unexpected_result(self):
         cmd = MCommand(result="foobar")
         with raises(
-            ValueError, message='expected "ok" or "error" result, but received: foobar'
+            ValueError, match=re.escape('expected "ok" or "error" result, but received: foobar')
         ):
             cmd.execute()
 
     def test_blank_result(self):
         cmd = MCommand(result="")
         with raises(
-            ValueError, message='expected "ok" or "error" result, but received: '
+            ValueError, match=re.escape('expected "ok" or "error" result, but received: ')
         ):
             cmd.execute()
 

--- a/tests/test_emulator.py
+++ b/tests/test_emulator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
-
+import re
 from unittest import mock
 
 import pytest
@@ -18,7 +18,7 @@ from py3270 import (
 class TestEmulator(object):
     def test_emulatorbase_exception(self):
         with pytest.raises(
-            Exception, message="EmulatorBase has been replaced by Emulator."
+            Exception, match=re.escape("EmulatorBase has been replaced by Emulator.")
         ):
             EmulatorBase()
 
@@ -41,7 +41,7 @@ class TestEmulator(object):
     def test_command_after_terminate(self, m_cmd):
         em = MEmulator.mock()
         em.terminate()
-        with pytest.raises(TerminatedError, message="Expecting TerminatedError"):
+        with pytest.raises(TerminatedError, match=re.escape("TerminalClient instance has been terminated")):
             em.connect("localhost")
 
     @mock.patch("py3270.Emulator.exec_command")
@@ -126,7 +126,7 @@ class TestEmulator(object):
     def test_string_get_too_much_data(self, m_ec):
         em = MEmulator.mock()
         m_ec.return_value.data = ["foobar", "baz"]
-        with pytest.raises(AssertionError, message="Expecting AssertionError"):
+        with pytest.raises(AssertionError):
             em.string_get(7, 9, 5)
 
     @mock.patch("py3270.Emulator.string_get")
@@ -160,7 +160,7 @@ class TestEmulator(object):
         em = MEmulator.mock()
         em.status.keyboard = b"E"
         with pytest.raises(
-            KeyboardStateError, message="keyboard not unlocked, state was: E"
+            KeyboardStateError, match=re.escape("keyboard not unlocked, state was: E")
         ):
             em.wait_for_field()
 
@@ -189,6 +189,6 @@ class TestEmulator(object):
     def test_fill_field_length_error(self):
         em = MEmulator.mock()
         with pytest.raises(
-            FieldTruncateError, message='length limit 5, but got "foobar"'
+            FieldTruncateError, match=re.escape('length limit 5, but got "foobar"')
         ):
             em.fill_field(1, 1, "foobar", 5)


### PR DESCRIPTION
Due to [the removal of the message keyword](https://docs.pytest.org/en/7.1.x/deprecations.html#message-parameter-of-pytest-raises) in `pytest.raises`, some tests were failing.
Fixing these.